### PR TITLE
Simpify Country names

### DIFF
--- a/src/collective/vocabularies/iso/vocabularies/countries.py
+++ b/src/collective/vocabularies/iso/vocabularies/countries.py
@@ -32,8 +32,11 @@ class Countries(object):
         countries = []
 
         for country in list(pycountry.countries):
-            countries.append((country.alpha_2, country.numeric, country.name))
-
+            if hasattr(country, "common_name"):
+                countries.append((country.alpha_2, country.numeric, country.common_name))
+            else:
+                countries.append((country.alpha_2, country.numeric, country.name))
+        
         terms = self.make_terms(countries)
 
         return SimpleVocabulary(terms)


### PR DESCRIPTION
Uses pycountries common name instead of official name. This improves the usability of the country selection. 

The upstream patch is to update pycountry common names. Pycountry doesn't seem to be actively maintained so it might be difficult to patch common names. Worth a shot.  